### PR TITLE
Add model from huggingface in container

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,10 +11,10 @@ verify_ssl = false
 [packages]
 numpy = "*"
 pynrrd = "*"
-pillow = "*"
+pillow = "==9.4.0"
 opencv-python = "*"
 ipython = "*"
-scikit-image = "*"
+scikit-image = "==0.19.3"
 pandas = "*"
 iopath = "*"
 imutils = "*"


### PR DESCRIPTION
Updates Dockerfile to download the model file from huggingface instead of datacommons.

Some fixes were needed to install requirements due to changes to the upstream container and various packages:
- setuptools is manually installed with support for use_2to3
  - pipenv needs use_2to3 to install pycallgraph
- pillow is now pinned
   - PIL.Image.LINEAR is missing in later versions
- scikit-image is now pinned
  - measure.perimeter() neighbourhood param has been renamed